### PR TITLE
Fix sprite wrapping/clipping behavior (closes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ I can definitely recommend giving it a try, I learned a lot during this journey.
 - Save and load current CPU state
 - Fullscreen mode and possibility to change background and foreground colors
 - Change CPU speed dynamically
-- Disable several quirks (enabled by default) and vertical wrapping (some ROMs require specific quirks or vertical wrapping disabled)  
+- Enable or disable several quirks (some ROMs require specific quirks)  
 - Debug windows displaying current register values, stack and executed opcodes as well as allowing to set breakpoints
 
 ## Screenshots
@@ -49,8 +49,6 @@ Without going too much into detail, the following are just guidelines and some R
 - Quirks
   - The default setting usually works good for legacy ROMs, however some title may need specific quirks turned off.
   - Modern ROMs written with Octo usually use different settings, therefore an Octo preset is included.
-- Vertical wrapping
-  - Should usually stay on, but there are specific ROMs where it needs to be turned off (e.g. BLITZ).
 - CPU speed
   - Legacy CHIP-8 ROMs usually work well around the default speed setting.
   - S-CHIP ROMs usually require one of the faster speed settings.

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -420,7 +420,6 @@ impl Emulator {
         }
 
         self.cpu_speed = self.gui.cpu_speed as u32;
-        self.cpu.vertical_wrapping = self.gui.flag_vertical_wrapping;
         self.mute = self.gui.flag_mute;
         self.sound.set_volume(self.gui.volume);
 
@@ -430,6 +429,8 @@ impl Emulator {
         self.cpu.quirk_draw = quirks.get(Quirk::Draw);
         self.cpu.quirk_jump = quirks.get(Quirk::Jump);
         self.cpu.quirk_vf_order = quirks.get(Quirk::VfOrder);
+        self.cpu.quirk_partialwrap_h = quirks.get(Quirk::PartialWrapH);
+        self.cpu.quirk_partialwrap_v = quirks.get(Quirk::PartialWrapV);
 
         self.step = self.gui.flag_step;
         self.gui.flag_step = false;

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -51,7 +51,6 @@ pub struct GUI {
     pub flag_pause: bool,
     pub cpu_speed: u32,
     cpu_multiplier: u32,
-    pub flag_vertical_wrapping: bool,
     pub flag_mute: bool,
     pub volume: f32,
 
@@ -167,7 +166,6 @@ impl GUI {
             cpu_speed: 0,
             cpu_multiplier: 1,
 
-            flag_vertical_wrapping: false,
             flag_mute: false,
             volume: 0.0,
 
@@ -468,6 +466,14 @@ impl GUI {
                         .build_with_ref(&ui, &mut self.quirks_settings.get_mut(Quirk::Jump));
                     MenuItem::new(im_str!("VF Order"))
                         .build_with_ref(&ui, &mut self.quirks_settings.get_mut(Quirk::VfOrder));
+                    MenuItem::new(im_str!("Partial Wrapping - Horizontal")).build_with_ref(
+                        &ui,
+                        &mut self.quirks_settings.get_mut(Quirk::PartialWrapH),
+                    );
+                    MenuItem::new(im_str!("Partial Wrapping - Vertical")).build_with_ref(
+                        &ui,
+                        &mut self.quirks_settings.get_mut(Quirk::PartialWrapV),
+                    );
                     ui.separator();
 
                     let mut preset_handler = QuirksPresetHandler::new(&mut self.quirks_settings);
@@ -486,8 +492,6 @@ impl GUI {
 
                     quirks_menu.end(&ui);
                 }
-                MenuItem::new(im_str!("Vertical Wrapping"))
-                    .build_with_ref(&ui, &mut self.flag_vertical_wrapping);
                 ui.separator();
 
                 let mut vol = (self.volume * 100.0) as u8;

--- a/src/gui/quirks_presets.rs
+++ b/src/gui/quirks_presets.rs
@@ -11,8 +11,10 @@ pub struct QuirksPresetHandler<'a> {
 }
 
 impl<'a> QuirksPresetHandler<'a> {
-    const QUIRKS_PRESET_DEFAULT: [bool; 5] = [true; 5];
-    const QUIRKS_PRESET_OCTO: [bool; 5] = [false, false, true, false, true];
+    const QUIRKS_PRESET_DEFAULT: [bool; QuirksSettings::NUM_QUIRKS] =
+        [true, true, true, true, true, false, false];
+    const QUIRKS_PRESET_OCTO: [bool; QuirksSettings::NUM_QUIRKS] =
+        [false, false, true, false, true, true, true];
 
     pub fn new(settings: &'a mut QuirksSettings) -> Self {
         Self { settings }
@@ -35,7 +37,7 @@ impl<'a> QuirksPresetHandler<'a> {
         }
     }
 
-    fn get_preset(&self, preset: QuirksPreset) -> [bool; 5] {
+    fn get_preset(&self, preset: QuirksPreset) -> [bool; QuirksSettings::NUM_QUIRKS] {
         match preset {
             QuirksPreset::Default => Self::QUIRKS_PRESET_DEFAULT,
             QuirksPreset::Octo => Self::QUIRKS_PRESET_OCTO,

--- a/src/gui/quirks_settings.rs
+++ b/src/gui/quirks_settings.rs
@@ -6,15 +6,21 @@ pub enum Quirk {
     Draw = 2,
     Jump = 3,
     VfOrder = 4,
+    PartialWrapH = 5,
+    PartialWrapV = 6,
 }
 
 pub struct QuirksSettings {
-    quirks: [bool; 5],
+    quirks: [bool; Self::NUM_QUIRKS],
 }
 
 impl QuirksSettings {
+    pub const NUM_QUIRKS: usize = 7;
+
     pub fn new() -> Self {
-        Self { quirks: [false; 5] }
+        Self {
+            quirks: [false; Self::NUM_QUIRKS],
+        }
     }
 
     pub fn get(&self, quirk: Quirk) -> bool {

--- a/src/video_memory.rs
+++ b/src/video_memory.rs
@@ -153,7 +153,11 @@ impl VideoMemory {
     }
 
     pub fn scroll_down(&mut self, lines: usize) {
-        let lines = if self.video_mode == VideoMode::Default { lines * 2 } else { lines };
+        let lines = if self.video_mode == VideoMode::Default {
+            lines * 2
+        } else {
+            lines
+        };
         for y in (0..self.render_height()).rev() {
             for x in 0..self.render_width() {
                 for plane in &[Plane::First, Plane::Second] {
@@ -172,7 +176,11 @@ impl VideoMemory {
     }
 
     pub fn scroll_up(&mut self, lines: usize) {
-        let lines = if self.video_mode == VideoMode::Default { lines * 2 } else { lines };
+        let lines = if self.video_mode == VideoMode::Default {
+            lines * 2
+        } else {
+            lines
+        };
         for y in 0..self.render_height() {
             for x in 0..self.render_width() {
                 for plane in &[Plane::First, Plane::Second] {
@@ -191,7 +199,11 @@ impl VideoMemory {
     }
 
     pub fn scroll_left(&mut self) {
-        let dist = if self.video_mode == VideoMode::Default { 8 } else { 4 };
+        let dist = if self.video_mode == VideoMode::Default {
+            8
+        } else {
+            4
+        };
         for x in 0..self.render_width() {
             for y in 0..self.render_height() {
                 for plane in &[Plane::First, Plane::Second] {
@@ -210,7 +222,11 @@ impl VideoMemory {
     }
 
     pub fn scroll_right(&mut self) {
-        let dist = if self.video_mode == VideoMode::Default { 8 } else { 4 };
+        let dist = if self.video_mode == VideoMode::Default {
+            8
+        } else {
+            4
+        };
         for x in (0..self.render_width()).rev() {
             for y in 0..self.render_height() {
                 for plane in &[Plane::First, Plane::Second] {


### PR DESCRIPTION
Fix original behavior if sprite are partly off screen by clipping them.
Introducing two new quirks to enable partial wrapping horizontally and vertically for compatibility reasons, especially since Octo uses partial wrapping.